### PR TITLE
Improve import with batches

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,8 @@ gem 'sidekiq'
 gem 'sidekiq-status'
 gem 'sidekiq-batch'
 
+gem 'activerecord-import', '~> 1.0.3'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'pry-remote'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,8 @@ GEM
       activemodel (= 5.2.3)
       activesupport (= 5.2.3)
       arel (>= 9.0)
+    activerecord-import (1.0.3)
+      activerecord (>= 3.2)
     activestorage (5.2.3)
       actionpack (= 5.2.3)
       activerecord (= 5.2.3)
@@ -303,6 +305,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-import (~> 1.0.3)
   annotate (~> 2.6.5)
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.3.1)

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -13,6 +13,7 @@
 #
 # Indexes
 #
+#  index_customers_on_email      (email) UNIQUE
 #  index_customers_on_import_id  (import_id)
 #
 
@@ -23,6 +24,7 @@ class Customer < ApplicationRecord
 
   validates :first_name, presence: true, length: { minimum: 2 }
   validates :email, format: { with: EMAIL_REGEXP }
+  validates_uniqueness_of :email
   validate :valid_age
 
   private

--- a/app/views/imports/show.html.erb
+++ b/app/views/imports/show.html.erb
@@ -12,3 +12,7 @@
     <a href="" class="btn btn-primary" onclick="javascript:window.location.reload(true)">Refresh</a>
   </div>
 </div>
+
+<script type="text/javascript">
+    setTimeout(function(){ location.reload(); }, 3000);
+</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
         <%= flash_messages %>
       </div>
       <%= yield %>
-      <%= debug(params) if Rails.env.development? %>
+      <%#= debug(params) if Rails.env.development? %>
     </div>
   </body>
 </html>

--- a/app/workers/import_customers_batch_worker.rb
+++ b/app/workers/import_customers_batch_worker.rb
@@ -1,0 +1,32 @@
+class ImportCustomersBatchWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: "import_customers", retry: 0, max_retries: 0
+
+  def perform(import_id, customers_data)
+    import = Import.find(import_id)
+
+    # assign for a proper import record
+    customers_data.map! { |c| c[:import_id] = import.id; c }
+
+    result = Customer.import(
+      customers_data,
+      validate: true,
+      # validate_uniqueness: true,
+      # ignore: true,
+      on_duplicate_key_ignore: true
+      # on_duplicate_key_update: [:email]
+    )
+
+    # logger.info "Result of import ##{import_id} with #{customers_data.size} data chunk(s):\r\n: #{customers_data.inspect} \r\n"
+    # logger.debug result.inspect
+
+    # upd counter in the imports table
+    imported_records_count = customers_data.size - result.failed_instances.size
+    Import.transaction do
+      import.with_lock do
+        import.increment!(:imported_records_count, imported_records_count)
+      end
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,7 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+ENV['RAILS_ENV'] ||= 'development'
 if (ENV['RAILS_ENV'].in?(%w(development test)))
   require 'dotenv/load'
   Dotenv.overload('.env', '.env.local')

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -22,4 +22,16 @@ Sidekiq.configure_server do |config|
   config.client_middleware do |chain|
     chain.add Sidekiq::Status::ClientMiddleware, expiration: 30.minutes
   end
+
+  if Rails.env.development? || Rails.env.test?
+    # config.logger.level = Logger::DEBUG
+    # ActiveRecord::Base.logger = Sidekiq::Logging.logger
+    # # ActiveRecord::Base.logger = Logger.new(STDOUT)
+    # #
+    # #
+
+    config.logger.level = ::Logger::DEBUG
+    Rails.logger = Sidekiq::Logging.logger
+    ActiveRecord::Base.logger = Sidekiq::Logging.logger
+  end
 end

--- a/db/migrate/20191104141359_add_email_index_to_customers.rb
+++ b/db/migrate/20191104141359_add_email_index_to_customers.rb
@@ -1,0 +1,9 @@
+class AddEmailIndexToCustomers < ActiveRecord::Migration[5.2]
+  def up
+    add_index :customers, :email, unique: true
+  end
+
+  def down
+    remove_index :customers, :email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_02_120329) do
+ActiveRecord::Schema.define(version: 2019_11_04_141359) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -41,17 +41,19 @@ ActiveRecord::Schema.define(version: 2019_11_02_120329) do
     t.bigint "import_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_customers_on_email", unique: true
     t.index ["import_id"], name: "index_customers_on_import_id"
   end
 
   create_table "imports", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "status"
+    t.string "status", default: "created", null: false
     t.datetime "started_at"
     t.datetime "completed_at"
-    t.integer "total_records_count"
-    t.integer "imported_records_count"
+    t.integer "total_records_count", default: 0, null: false
+    t.integer "imported_records_count", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["status"], name: "index_imports_on_status"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/spec/factories/customer_factory.rb
+++ b/spec/factories/customer_factory.rb
@@ -13,6 +13,7 @@
 #
 # Indexes
 #
+#  index_customers_on_email      (email) UNIQUE
 #  index_customers_on_import_id  (import_id)
 #
 

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -13,6 +13,7 @@
 #
 # Indexes
 #
+#  index_customers_on_email      (email) UNIQUE
 #  index_customers_on_import_id  (import_id)
 #
 
@@ -30,6 +31,7 @@ RSpec.describe Customer, type: :model do
   describe 'validations' do
     it { is_expected.to validate_presence_of :first_name }
     it { is_expected.to validate_length_of(:first_name).is_at_least(2) }
+    it { is_expected.to validate_uniqueness_of(:email) }
 
     context 'when email' do
       subject(:customer) { build(:customer) }

--- a/spec/workers/import_customers_batch_worker_spec.rb
+++ b/spec/workers/import_customers_batch_worker_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ImportCustomersBatchWorker, type: :worker do
+  it { is_expected.to be_processed_in :import_customers }
+  it { is_expected.to be_retryable 0 }
+
+  context 'when inline' do
+    before do
+      Sidekiq::Testing.inline!
+    end
+
+    context 'with created import and valid data hash' do
+      subject(:job) { described_class.perform_async(import.id, stub_customer_data_array) }
+
+      let(:stub_customer_data_array) do
+        [
+          {
+            first_name: 'first_name',
+            last_name: 'last_name',
+            email: 'ololo@gmail.com',
+            dob: "2001-10-01 00:00:00 UTC"
+          }
+        ]
+      end
+
+      let!(:import) { create(:import) }
+
+      it 'imports record to the db' do
+        expect { job }.to change(Customer, :count).by(1)
+      end
+
+      it 'assigns correct import reference for the customer' do
+        job
+
+        expect(Customer.last.import).to eq(import)
+      end
+
+      it 'increments imported_records_count counter' do
+        expect { job }.to change { import.reload.imported_records_count }.by(1)
+      end
+
+      it 'calls single batch SQL import' do
+        allow(Customer).to receive(:import).and_call_original
+
+        job
+
+        expect(Customer).to have_received(:import).once
+      end
+    end
+  end
+end

--- a/spec/workers/import_worker_spec.rb
+++ b/spec/workers/import_worker_spec.rb
@@ -45,7 +45,7 @@ describe ImportWorker, type: :worker do
     let!(:import) { create(:import, :with_5_customers) }
 
     it 'uses CSV parser' do
-      allow(ImportCustomerWorker).to receive(:perform_async)
+      allow(ImportCustomersBatchWorker).to receive(:perform_async)
 
       allow(Import::Csv::Parse).to receive(:new).with(import).and_call_original
 
@@ -55,11 +55,11 @@ describe ImportWorker, type: :worker do
     end
 
     it 'delegates row processing to the ImportCustomerWorker' do
-      allow(ImportCustomerWorker).to receive(:perform_async)
+      allow(ImportCustomersBatchWorker).to receive(:perform_async)
 
       described_class.perform_async(import.id)
 
-      expect(ImportCustomerWorker).to have_received(:perform_async).exactly(5).times
+      expect(ImportCustomersBatchWorker).to have_received(:perform_async).once
     end
 
     context 'when CSV parser called with some stubbed data' do
@@ -72,11 +72,11 @@ describe ImportWorker, type: :worker do
       end
 
       it 'delegates row processing to the ImportCustomerWorker with the same values' do
-        allow(ImportCustomerWorker).to receive(:perform_async)
+        allow(ImportCustomersBatchWorker).to receive(:perform_async)
 
         described_class.perform_async(import.id)
 
-        expect(ImportCustomerWorker).to have_received(:perform_async).with(import.id, first_name: 'ololo').once
+        expect(ImportCustomersBatchWorker).to have_received(:perform_async).with(import.id, [{first_name: 'ololo'}]).once
       end
     end
   end


### PR DESCRIPTION
Improve database insertions: 
- split it by batches and run single-query INSERT ... VALUES(...).
 - add uniqueness on customers.email field with INSERT IGNORE to speedup inserts and now store duplicates